### PR TITLE
Update dependencies workflow branch suffix

### DIFF
--- a/.github/workflows/dependencies-update.yml
+++ b/.github/workflows/dependencies-update.yml
@@ -45,6 +45,9 @@ jobs:
           echo "changed=false" >> $GITHUB_OUTPUT
           git diff --cached --quiet || echo "changed=true" >> $GITHUB_OUTPUT
 
+      - name: Set branch timestamp
+        run: echo "BRANCH_TIMESTAMP=$(date +'%Y%m%d-%H%M%S')" >> $GITHUB_ENV
+
       - name: Create Pull Request
         if: steps.git-check.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v5
@@ -76,4 +79,4 @@ jobs:
             ---
             > Please merge if all checks pass and the application works as expected.
           branch: chore/deps-update-${{ github.run_id }}
-          branch-suffix: timestamp
+          branch-suffix: ${{ env.BRANCH_TIMESTAMP }}


### PR DESCRIPTION
## Summary
- add step to set timestamp env var
- use timestamp in branch suffix for dependency update PRs

## Testing
- `npm run lint` *(fails: couldn't find eslint.config.js)*
- `npm run type-check` *(fails: TS18003 no inputs were found)*

------
https://chatgpt.com/codex/tasks/task_e_686611b03c948323b4a732a3e01f6506